### PR TITLE
Bugfix new dir on update

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -318,7 +318,7 @@ min-public-methods=1
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=builtins.BaseException,builtins.Exception
+overgeneral-exceptions=
 
 
 [FORMAT]

--- a/pyupgrader/update.py
+++ b/pyupgrader/update.py
@@ -39,7 +39,7 @@ class UpdateManager:
         Path to the local config file
     - hash_db_path: str
         Path to the local hash database
-        
+
     Methods:
     - check_update() -> dict
         Compare cloud and local version and return a dict with the results

--- a/pyupgrader/utilities/file_updater.py
+++ b/pyupgrader/utilities/file_updater.py
@@ -77,7 +77,9 @@ if __name__ == "__main__":
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H_%M_%S")
         dump_dir = os.path.join(os.path.dirname(__file__), "crash_dump")
         os.makedirs(dump_dir, exist_ok=True)
-        crash_file = os.path.join(os.path.dirname(__file__), "crash_dump", f"update_crash_{timestamp}.txt")
+        crash_file = os.path.join(
+            os.path.dirname(__file__), "crash_dump", f"update_crash_{timestamp}.txt"
+        )
         with open(crash_file, "w", encoding="utf-8") as f:
             f.write(traceback.format_exc())
         raise Exception(f"Update failed. Crash file created at {crash_file}") from e

--- a/pyupgrader/utilities/file_updater.py
+++ b/pyupgrader/utilities/file_updater.py
@@ -74,8 +74,10 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-        crash_file = os.path.join(os.path.dirname(__file__), f"update_crash_{timestamp}.txt")
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H_%M_%S")
+        dump_dir = os.path.join(os.path.dirname(__file__), "crash_dump")
+        os.makedirs(dump_dir, exist_ok=True)
+        crash_file = os.path.join(os.path.dirname(__file__), "crash_dump", f"update_crash_{timestamp}.txt")
         with open(crash_file, "w", encoding="utf-8") as f:
             f.write(traceback.format_exc())
         raise Exception(f"Update failed. Crash file created at {crash_file}") from e

--- a/pyupgrader/utilities/file_updater.py
+++ b/pyupgrader/utilities/file_updater.py
@@ -31,6 +31,20 @@ def main():
         cloud_hash_db_path = update_details["cloud_hash_db_path"]
         cleanup = update_details["cleanup"]
 
+    # Update the files
+    for file in update_files:
+        source = os.path.join(downloads_dir, file)
+        destination = os.path.join(project_path, file)
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        if os.path.exists(destination):
+            os.remove(destination)
+        shutil.copy(source, destination)
+
+    for file in del_files:
+        destination = os.path.join(project_path, file)
+        if os.path.exists(destination):
+            os.remove(destination)
+
     # Replace config and hash db
     if os.path.exists(cloud_config_path):
         source = cloud_config_path
@@ -49,20 +63,6 @@ def main():
         shutil.copy(source, destination)
     else:
         raise FileNotFoundError(f"Cloud hash db not found at '{cloud_hash_db_path}'")
-
-    # Update the files
-    for file in update_files:
-        source = os.path.join(downloads_dir, file)
-        destination = os.path.join(project_path, file)
-        os.makedirs(os.path.dirname(destination), exist_ok=True)
-        if os.path.exists(destination):
-            os.remove(destination)
-        shutil.copy(source, destination)
-
-    for file in del_files:
-        destination = os.path.join(project_path, file)
-        if os.path.exists(destination):
-            os.remove(destination)
 
     if cleanup:
         shutil.rmtree(downloads_dir)

--- a/pyupgrader/utilities/file_updater.py
+++ b/pyupgrader/utilities/file_updater.py
@@ -6,6 +6,7 @@ import pickle
 import shutil
 import sys
 import datetime
+import traceback
 from time import sleep
 
 
@@ -53,6 +54,7 @@ def main():
     for file in update_files:
         source = os.path.join(downloads_dir, file)
         destination = os.path.join(project_path, file)
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
         if os.path.exists(destination):
             os.remove(destination)
         shutil.copy(source, destination)
@@ -73,7 +75,7 @@ if __name__ == "__main__":
         main()
     except Exception as e:
         timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-        crash_file = f"update_crash_{timestamp}.txt"
-        with open(os.path.join(os.path.dirname(__file__), crash_file), "w", encoding="utf-8") as f:
-            f.write(str(e))
-        raise e
+        crash_file = os.path.join(os.path.dirname(__file__), f"update_crash_{timestamp}.txt")
+        with open(crash_file, "w", encoding="utf-8") as f:
+            f.write(traceback.format_exc())
+        raise Exception(f"Update failed. Crash file created at {crash_file}") from e

--- a/tests/WebTestDirectory/main.py
+++ b/tests/WebTestDirectory/main.py
@@ -3,7 +3,7 @@ from pyupgrader.utilities.helper import Config
 import os
 
 # TODO: Change branch to master when merging into master
-pyupgrader_url = r"https://raw.githubusercontent.com/Trogiken/PyUpgrader/staging/tests/WebTestDirectory/.pyupgrader"  # Replace with your info inside the {}
+pyupgrader_url = r"https://raw.githubusercontent.com/Trogiken/PyUpgrader/bugfix-new-dir-on-update/tests/WebTestDirectory/.pyupgrader"  # Replace with your info inside the {}
 local_project_path = os.path.dirname(__file__)  # Assuming the entry point module is in the upper most directory
 
 update_manager = pyupgrader.UpdateManager(pyupgrader_url, local_project_path)


### PR DESCRIPTION
A new update being added in an update would cause a crash in the update process. This PR fixes this along with adding a dump directory for crash logs.