### PR TITLE
Relative Path Rework

### DIFF
--- a/pyupgrader/utilities/build.py
+++ b/pyupgrader/utilities/build.py
@@ -172,7 +172,7 @@ class Builder:
     def _create_hash_db(self):
         """Creates the hash database"""
         LOGGER.info("Creating hash database at '%s'", self._hash_db_path)
-        hasher = hashing.Hasher(project_name=os.path.basename(self.project_path))
+        hasher = hashing.Hasher()
 
         self.exclude_paths.append(self._pyudpdate_folder)
         self.exclude_patterns.append(r".*/__pycache__/.*")

--- a/pyupgrader/utilities/hashing.py
+++ b/pyupgrader/utilities/hashing.py
@@ -232,15 +232,9 @@ class Hasher:
     """
     A class that provides methods for hashing files and creating hash databases.
 
-    Attributes:
-    - path_basename (str): The basename of the path. Used to create relative file paths.
-        The create_hash_db method sets this attribute automatically,
-        but it can be set manually if needed.
-
     Methods:
     - create_hash(self, file_path: str) -> (str, str):
         Creates a hash from file bytes using the chunk method.
-        Returns the relative file path and hash as a string.
     - create_hash_db(self, hash_dir_path: str, db_save_path: str,
                     exclude_paths=None, exclude_patterns=None
                     ) -> str:
@@ -249,7 +243,7 @@ class Hasher:
     """
 
     def __init__(self):
-        self.path_basename = None
+        self._path_basename = None
 
     def __str__(self) -> str:
         return "Hasher object"
@@ -312,7 +306,9 @@ class Hasher:
         Returns:
         - Tuple[str, str]: A tuple containing the relative file path and hash as a string.
         """
-        relative_file_path = helper.normalize_paths(file_path.split(self.path_basename)[-1]).lstrip(
+        relative_file_path = helper.normalize_paths(
+            file_path.split(self._path_basename)[-1]
+        ).lstrip(
             "/"
         )  # Remove leading slash and convert to relative path
         LOGGER.debug("Relative file path: %s", relative_file_path)
@@ -576,8 +572,8 @@ class Hasher:
             raise Exception(f"Directory '{hash_dir_path}' does not exist")
 
         # Set basename for relative file paths
-        self.path_basename = os.path.basename(hash_dir_path)
-        LOGGER.debug("Project name: %s", self.path_basename)
+        self._path_basename = os.path.basename(hash_dir_path)
+        LOGGER.debug("Project name: %s", self._path_basename)
 
         if os.path.exists(db_save_path):
             try:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', encoding="utf-8") as f:
 
 setup(
     name='pyupgrader',
-    version='2.5.11b2',
+    version='2.5.12b2',
     author='Noah Blaszak',
     author_email='technology.misc@gmail.com',
     description='Keep your Python code up to date on client machines.',

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -94,13 +94,15 @@ class HasherTestCase(unittest.TestCase):
         create_dir_structure(self.test_dir)
         os.mkdir(self.save_dir)
 
-        self.hasher = Hasher("test_project")
+        self.hasher = Hasher()
     
     def tearDown(self):
         shutil.rmtree(self.test_dir)
         shutil.rmtree(self.save_dir)
 
     def test_create_hash(self):
+        # TODO: Shouldnt have to set this at all
+        self.hasher.path_basename = os.path.basename(self.test_dir)  # set path_basename manually
         file_path = os.path.join(self.test_dir, "file1.txt")  # created by create_dir_structure
         # hash file
         with open(file_path, "rb") as file:

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -101,20 +101,15 @@ class HasherTestCase(unittest.TestCase):
         shutil.rmtree(self.save_dir)
 
     def test_create_hash(self):
-        # TODO: Shouldnt have to set this at all
-        self.hasher.path_basename = os.path.basename(self.test_dir)  # set path_basename manually
         file_path = os.path.join(self.test_dir, "file1.txt")  # created by create_dir_structure
         # hash file
         with open(file_path, "rb") as file:
             file_content = file.read()
             file_hash = hashlib.sha256(file_content).hexdigest()
         
-        expected_relative_file_path = "file1.txt"
         expected_file_hash = file_hash
+        file_hash = self.hasher.create_hash(file_path)
 
-        relative_file_path, file_hash = self.hasher.create_hash(file_path)
-
-        self.assertEqual(relative_file_path, expected_relative_file_path)
         self.assertEqual(file_hash, expected_file_hash)
 
     def test_create_hash_db(self):


### PR DESCRIPTION
No longer does the Hasher class need a project name attribute to be entered when creating it's object. It automatically derives this from the _entered hash directory_ using `os.path.basename()`

This refactoring also means that the `Hasher.create_hash` method can work by just providing the file path you want to hash, without relying on the project name to create a relative path. This functionality was moved to `Hasher._create_path_and_hash`